### PR TITLE
Sudo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ This examples playbook uses the role twice:
                 - ssh-ed25519 AAAAC3NzaC1lZDI1iweE....
                 - ssh-rsa AAAAB3NzaC1yc2EAAAADAQAD....
                 - ssh-ed25519 AAAAC3NzaC1lZDIDDJ72....
+          - name: admin2
+            password: "{{ 'hackme2' | password_hash('sha512', 'mysalt') }}"
+            comment: Extra admin account with passwordless sudo
+            ssh_authorized_keys:
+              pubkeys:
+                - ssh-ed25519 AAAAC3NzaC1lZDI1iweE....
+            sudo_config: "ALL=(ALL) NOPASSWD:ALL"
 ```
 
 

--- a/tasks/account_disable.yml
+++ b/tasks/account_disable.yml
@@ -6,3 +6,8 @@
     remove: "{{ account.remove | default(omit) }}"
     force: "{{ account.force | default(omit) }}"
   when: account.name is defined
+
+- name: "Ensure sudo configuration is removed for user {{ account.name }}"
+  file:
+    path: "/etc/sudoers.d/account_{{ account.name }}"
+    state: absent

--- a/tasks/sudo_config.yml
+++ b/tasks/sudo_config.yml
@@ -1,0 +1,11 @@
+---
+- name: "Ensure sudo configuration is available for user {{ account.name }}"
+  copy:
+    content: "{{ account.name }} {{ account.sudo_config }}"
+    dest: "/etc/sudoers.d/account_{{ account.name }}"
+    owner: root
+    group: root
+    mode: '0440'
+    validate: /usr/sbin/visudo -cf %s
+  when:
+    - account.sudo_config is defined

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -40,3 +40,4 @@ _our_params:
   - ssh_config
   - ssh_config_template
   - ssh_keypairs
+  - sudo_config


### PR DESCRIPTION
New user parameter `sudo_config`. Example config:

```yaml
user_accounts:
  - name: admin2
    state: present
    sudo_config: "ALL=(ALL) NOPASSWD:ALL"
```
This will cause a file `/etc/sudoers.d/account_admin2` to be created with content:

```
admin2 ALL=(ALL) NOPASSWD:ALL
```

The file will be removed when the account is removed (by using `state: absent`)